### PR TITLE
Use ssl_token_link instead of token_link

### DIFF
--- a/lib/sendshapes/client.rb
+++ b/lib/sendshapes/client.rb
@@ -12,11 +12,11 @@ module Sendshapes
     def create_transaction(file_path, receiver_email, print_value, partner_job_id)
       post_data = { stl_file: File.new(file_path), api_key: api_key, token: token, receiver_email: receiver_email,
                     print_value: print_value, partner_job_id: partner_job_id}
-      post('/api_upload_partner_stl', post_data)['data']['token_link']
+      post('/api_upload_partner_stl', post_data)['data']['ssl_token_link']
     end
 
     protected
-    
+
     def token
       @token ||= get('/api_create_partner_token', api_key: api_key)['data']['token']
     end


### PR DESCRIPTION
In order to use iframe in SSL protected website, ssl_token_link
should be used.
